### PR TITLE
readline 8.1.2

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -14,6 +14,8 @@ build:
   run_exports:
     # change soname at major ver: https://abi-laboratory.pro/tracker/timeline/readline/
     - {{ pin_subpackage('readline') }}
+  ignore_run_exports:
+    - ncurses
 
 requirements:
   build:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,4 +1,4 @@
-{% set version = "8.1" %}
+{% set version = "8.1.2" %}
 
 package:
   name: readline
@@ -6,7 +6,7 @@ package:
 
 source:
   url: https://ftp.gnu.org/gnu/readline/readline-{{ version }}.tar.gz
-  sha256: f8ceb4ee131e3232226a17f51b164afc46cd0b9e6cef344be87c65962cb82b02
+  sha256: 7589a2381a8419e68654a47623ce7dfcb756815c8fee726b98f90bf668af7bc6
 
 build:
   skip: true  # [win]
@@ -37,16 +37,12 @@ test:
   {% endfor %}
 
 about:
-  home: https://cnswww.cns.cwru.edu/php/chet/readline/rltop.html
-  license: GPL-3.0
+  home: https://tiswww.case.edu/php/chet/readline/rltop.html
+  license: GPL-3.0-only
   license_file: COPYING
   summary: library for editing command lines as they are typed in
-  description: |
-    The standard Python readline extension statically linked against the GNU
-    readline library.
-  doc_url: https://pypi.python.org/pypi/readline
-  dev_url: https://github.com/ludwigschwardt/python-gnureadline
-  doc_source_url: https://github.com/ludwigschwardt/python-gnureadline
+  dev_url: http://git.savannah.gnu.org/cgit/readline.git/
+  doc_url: https://tiswww.case.edu/php/chet/readline/rltop.html
 
 extra:
   recipe-maintainers:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -41,8 +41,14 @@ test:
 about:
   home: https://tiswww.case.edu/php/chet/readline/rltop.html
   license: GPL-3.0-only
+  license_family: GPL
   license_file: COPYING
   summary: library for editing command lines as they are typed in
+  description: |
+    The GNU Readline library provides a set of functions for use by applications 
+    that allow users to edit command lines as they are typed in. 
+    The Readline library includes additional functions to maintain a list of previously-entered command lines, 
+    to recall and perhaps reedit those lines, and perform csh-like history expansion on previous commands.
   dev_url: http://git.savannah.gnu.org/cgit/readline.git/
   doc_url: https://tiswww.case.edu/php/chet/readline/rltop.html
 


### PR DESCRIPTION
Upstream changelog: http://git.savannah.gnu.org/cgit/readline.git/tree/CHANGES
Readme: http://git.savannah.gnu.org/cgit/readline.git/tree/README
Installation: http://git.savannah.gnu.org/cgit/readline.git/tree/INSTALL
Patch 2 for v8.1: http://git.savannah.gnu.org/cgit/readline.git/commit/?id=5263c0d88064fda96292335d12eec1733f91cdc9


Actions:
1. Fix license
2. Update version and sha256, 
3. Update home, dev, doc urls
4. Remove doc_source_url
5. Update description
6. Add license_family
7. Add ncurse to ignore_run_exports

Result:
- all-succeeded