### PR TITLE
Fix broken ncurses linking

### DIFF
--- a/recipe/build.sh
+++ b/recipe/build.sh
@@ -3,6 +3,9 @@
 ./configure --prefix=${PREFIX}  \
             --build=${BUILD}    \
             --host=${HOST}      \
+            --enable-multibyte  \
+            --with-curses       \
+            --disable-install-examples  \
             || { cat config.log; exit 1; }
-make SHLIB_LIBS="$(pkg-config --libs ncurses)" -j${CPU_COUNT} ${VERBOSE_AT}
+make SHLIB_LIBS="$(pkg-config --libs ncursesw)" -j${CPU_COUNT} ${VERBOSE_AT}
 make install

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -10,12 +10,10 @@ source:
 
 build:
   skip: true  # [win]
-  number: 0
+  number: 1
   run_exports:
     # change soname at major ver: https://abi-laboratory.pro/tracker/timeline/readline/
     - {{ pin_subpackage('readline') }}
-  ignore_run_exports:
-    - ncurses
 
 requirements:
   build:
@@ -24,10 +22,10 @@ requirements:
     - make
   host:
     - ncurses
-  run:
-    - ncurses
 
 test:
+  requires:
+    - python 3.*
   commands:
   {% set readline_libs = [
     'libreadline',
@@ -37,6 +35,8 @@ test:
     - test -f ${PREFIX}/lib/{{ lib }}.a
     - test -f ${PREFIX}/lib/{{ lib }}${SHLIB_EXT}  # [not win]
   {% endfor %}
+    # catch missing termcap/ncurses linkage problems
+    - python -c "import readline"
 
 about:
   home: https://tiswww.case.edu/php/chet/readline/rltop.html


### PR DESCRIPTION
- Force this recipe to use the conda-supplied `ncurses`, rather than running off and picking up any system-installed (lib)termcap.
- Update `pkg-config` command to search for `ncursesw` rather than `ncurses` and enable multi-byte support to match what's actually provided in the Anaconda `ncurses` package.
- Add a test to check for missing symbol, DSO load problems